### PR TITLE
Enable Automated Logging via GitHub Actions

### DIFF
--- a/.github/workflows/scrape.yml
+++ b/.github/workflows/scrape.yml
@@ -1,0 +1,34 @@
+name: 🔁 Gym Tracker Auto-Logger
+
+on:
+  schedule:
+    - cron: "*/15 * * * *"  # every 15 minutes
+  workflow_dispatch:
+
+jobs:
+  run-logger:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repo
+        uses: actions/checkout@v3
+
+      - name: Set up Python
+        uses: actions/setup-python@v4
+        with:
+          python-version: "3.11"
+
+      - name: Install dependencies
+        run: |
+          python -m pip install --upgrade pip
+          pip install -r requirements.txt
+
+      - name: Restore Google credentials
+        run: |
+          echo "$GOOGLE_CREDS_BASE64" | base64 -d > credentials.json
+
+      - name: Run gym logger
+        env:
+          GYM_EMAIL: ${{ secrets.GYM_EMAIL }}
+          GYM_PASSWORD: ${{ secrets.GYM_PASSWORD }}
+          GOOGLE_CREDS_FILE: credentials.json
+        run: python main.py


### PR DESCRIPTION
This PR integrates scheduled GitHub Actions to run the logger every 15 minutes.
Includes setup for credentials, Google Sheets logging, and environment secrets.